### PR TITLE
Update main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 *******************************************************************************/
 
 #include <sys/wait.h>
+#include <sys/types.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
In case of Error:
```
main.c: In function 'lsh_launch':
main.c:103:3: error: unknown type name 'pid_t'
   pid_t pid;
   ^
```

"In older Posix standards, pid_t was only defined in <sys/types.h>, but since Posix.1-2001 (Issue 7) it is also in <unistd.h>. However, in order to get definitions in Posix.1-2001, you must define an appropriate feature test macro before including any standard header file."