### PR TITLE
Fix handling of EOF in lsh_read_line()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -181,14 +181,19 @@ char *lsh_read_line(void)
     // Read a character
     c = getchar();
 
-    if (c == EOF) {
+    if (c == EOF && feof(stdin)) {
+      free(buffer);
       exit(EXIT_SUCCESS);
+    } else if (c == EOF && ferror(stdin)) {
+      perror("getchar (EOF)");
+      free(buffer);
+      exit(EXIT_FAILURE);
     } else if (c == '\n') {
       buffer[position] = '\0';
       return buffer;
-    } else {
-      buffer[position] = c;
     }
+
+    buffer[position] = c;
     position++;
 
     // If we have exceeded the buffer, reallocate.


### PR DESCRIPTION
Hi again : ) I have implemented the changes (with your suggestion) and hope everything looks good! I also noticed you opted to mix `perror()` and `fprintf()` elsewhere in your code (in places where `errno` would be set), but I didn't touch any of that because, well, your choices were more than likely intentional!

Fixes #25 