### PR TITLE
Updated execvp() error message for command not found. 

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -112,7 +112,7 @@ int lsh_launch(char **args)
       if (errno == ENOENT) {
       	fprintf(stderr, "lsh: command not found: %s\n", args[0]);
       } else {
-      	perror("jsh");
+      	perror("lsh");
       }
       exit(EXIT_FAILURE);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 /*
   Function Declarations for builtin shell commands:
@@ -108,7 +109,11 @@ int lsh_launch(char **args)
   if (pid == 0) {
     // Child process
     if (execvp(args[0], args) == -1) {
-      fprintf(stderr, "lsh: command not found: %s\n", args[0]);
+      if (errno == ENOENT) {
+      	fprintf(stderr, "lsh: command not found: %s\n", args[0]);
+      } else {
+      	perror("jsh");
+      }
       exit(EXIT_FAILURE);
     }
     exit(EXIT_FAILURE);

--- a/src/main.c
+++ b/src/main.c
@@ -108,7 +108,8 @@ int lsh_launch(char **args)
   if (pid == 0) {
     // Child process
     if (execvp(args[0], args) == -1) {
-      perror("lsh");
+      fprintf(stderr, "lsh: command not found: %s\n", args[0]);
+      exit(EXIT_FAILURE);
     }
     exit(EXIT_FAILURE);
   } else if (pid < 0) {


### PR DESCRIPTION
First of all, thank you for this great timeless tutorial! 
Upon entering an unknown command into lsh, the shell would return `lsh: No such file or directory`. My fix checks for this case and returns the error message `lsh: command not found:` instead.

I believe when `execvp()` returns upon not being able to find the shell command's file, it sets global var `errno` to `ENOENT`. `perror()` uses `errno` to print its error message. Checking for this `ENOENT` case allows for a more detailed error message. There are other cases where `execvp()` may return upon error (e.g. doesn't have execute permission), so we keep that case for `perror()`. 

I realize that this error message fix falls into between a 'new feature' and a 'bug fix' regarding the contribution guidelines, but I think it's a helpful tweak that provides more informative and zsh-like error handling. Please let me know any thoughts, thanks!